### PR TITLE
Small adjusts on CSS

### DIFF
--- a/src/js/style.css
+++ b/src/js/style.css
@@ -4,7 +4,7 @@
 /* Extension specific */
 
 #__better_github_pr {
-    margin-top: 2opx;
+    margin-top: 20px;
     padding: 10px;
     width: 240px;
     overflow: auto;

--- a/src/js/style.css
+++ b/src/js/style.css
@@ -4,13 +4,15 @@
 /* Extension specific */
 
 #__better_github_pr {
-    margin-top: 21px;
+    margin-top: 2opx;
     padding: 10px;
     width: 240px;
     overflow: auto;
     height: calc(100vh - 61px);
     background-color: #fafbfc;
     border: 1px solid #e1e4e8;
+    box-sizing: border-box;
+    border-radius: 3px;
 }
 
 #__better_github_pr > div {


### PR DESCRIPTION
This adjust is to  keep the layout like the github PR page.
The box-sizing is to keep the size of div when using border with 1px, and then we can remove it 1px from margin top
and the border radius is like the border radius of others divs from github page: 3px

PS: Thank you for this extension, i really appreciate it