### PR TITLE
Shrink comment box to fit

### DIFF
--- a/src/js/style.css
+++ b/src/js/style.css
@@ -32,6 +32,10 @@
     z-index: 1;
 }
 
+.enable_better_github_pr .comment-holder {
+    max-width: 710px;
+}
+
 /* react-treeview */
 
 .tree-view_item {


### PR DESCRIPTION
Shrink the comment box down to fit into the provided space.
Currently the comment box overhangs (default is 780px).

Current:
![image](https://user-images.githubusercontent.com/7288322/39559721-789b894c-4eec-11e8-8686-fd216fa3d90a.png)

This PR:
![image](https://user-images.githubusercontent.com/7288322/39559723-7d24d4c8-4eec-11e8-87b1-8bacb6919516.png)