### PR TITLE
Add comment icon to files with comments

### DIFF
--- a/src/js/components/branch.jsx
+++ b/src/js/components/branch.jsx
@@ -2,9 +2,9 @@ import React from 'react'
 import TreeView from 'react-treeview'
 import File from './file'
 
-const Branch = ({ nodeLabel, list, href }) => {
+const Branch = ({ nodeLabel, list, href, has_comments }) => {
   if (href) {
-    return <File name={nodeLabel} href={href} />
+    return <File name={nodeLabel} href={href} has_comments={has_comments}/>
   }
 
   return (

--- a/src/js/components/file.jsx
+++ b/src/js/components/file.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import fileIcons from 'file-icons-js'
 
-const File = ({ name, href }) => {
+const File = ({ name, href, has_comments }) => {
   const className = fileIcons.getClassWithColor(name)
   return (
     <div className='github-pr-file'>
       <span className={`icon ${className}`} />
-      <a href={href} className='link-gray-dark'>{name}</a>
+      <a href={href} className='link-gray-dark'>{name}{has_comments ? ' 💬' : ''}</a>
     </div>
   )
 }

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -36,12 +36,13 @@ export const createFileTree = () => {
     list: []
   }
 
-  files.forEach(({ parts, href }) => {
+  files.forEach(({ parts, href }, index) => {
+    let has_comments = !!document.getElementsByClassName('diff-table')[index].querySelectorAll('.inline-comments').length;
     let location = tree
     parts.forEach((part, index) => {
       let node = location.list.find(node => node.nodeLabel === part)
       if (!node) {
-        node = { nodeLabel: part, list: [], href: (index === parts.length - 1) ? href : null }
+        node = { nodeLabel: part, list: [], href: (index === parts.length - 1) ? href : null, has_comments }
         location.list.push(node)
       }
       location.list = location.list.sort(sorter)


### PR DESCRIPTION
Closes #8 

Adds a comment icon to the end of filenames which have comments.

Uses this icon: &#128172; `&#128172;`

Example on Windows 10 - Chrome:
![image](https://user-images.githubusercontent.com/7288322/39733090-0fbac370-52c5-11e8-91ec-f6400222ebde.png)
