### PR TITLE
Update root tree on big PR

### DIFF
--- a/src/js/components/tree.jsx
+++ b/src/js/components/tree.jsx
@@ -139,7 +139,8 @@ class Tree extends React.Component {
   }
 
   render () {
-    const { root, filter, show, visibleElement } = this.state
+    const { filter, show, visibleElement } = this.state
+    const { root } = this.props
 
     if (!show) {
       return null

--- a/src/js/components/tree.jsx
+++ b/src/js/components/tree.jsx
@@ -34,6 +34,12 @@ class Tree extends React.Component {
       filter: null
     }
   }
+  
+  componentDidUpdate (prevProps) {
+    if (this.props.root !== prevProps.root) {
+      this.setState({root: this.props.root})
+    }
+  }
 
   componentDidMount () {
     window.addEventListener('DOMContentLoaded', this.onScroll, false)
@@ -139,8 +145,7 @@ class Tree extends React.Component {
   }
 
   render () {
-    const { filter, show, visibleElement } = this.state
-    const { root } = this.props
+    const { root, filter, show, visibleElement } = this.state
 
     if (!show) {
       return null


### PR DESCRIPTION
When the PR is too fat, it take some time to load all the tree, so we have a timeout wich bind the tree until we get all files.
Unfortunly the HTML will never be updated cause the root state was never updated