### PR TITLE
Add diff stats styling

### DIFF
--- a/src/js/components/branch.jsx
+++ b/src/js/components/branch.jsx
@@ -2,10 +2,10 @@ import React from 'react'
 import TreeView from 'react-treeview'
 import File from './file'
 
-const Branch = ({ nodeLabel, list, href, hasComments, isDeleted, diffElement, visibleElement }) => {
+const Branch = ({ nodeLabel, list, href, hasComments, isDeleted, diffElement, diffStats, visibleElement }) => {
   if (href) {
     const isVisible = (diffElement === visibleElement)
-    return <File name={nodeLabel} href={href} hasComments={hasComments} isDeleted={isDeleted} isVisible={isVisible} />
+    return <File name={nodeLabel} href={href} hasComments={hasComments} isDeleted={isDeleted} isVisible={isVisible} diffStats={diffStats} />
   }
 
   return (

--- a/src/js/components/file.jsx
+++ b/src/js/components/file.jsx
@@ -4,16 +4,38 @@ import fileIcons from 'file-icons-js'
 const highlightColor = '#ebebeb'
 const transparentColor = 'transparent'
 
-const File = ({ name, href, hasComments, isDeleted, isVisible }) => {
+const AdditionBlock = <span className='change-block addition' />
+const DeletionBlock = <span className='change-block deletion' />
+
+const File = ({ name, href, hasComments, isDeleted, isVisible, diffStats }) => {
   const className = fileIcons.getClassWithColor(name)
   const style = {
     background: isVisible ? highlightColor : transparentColor,
     textDecoration: isDeleted ? 'line-through' : null
   }
+  const changeBlocks = []
+  let changeNumber
+  if (diffStats) {
+    for (let i = 0; i < Math.log(diffStats.additions); i++) {
+      changeBlocks.push(AdditionBlock)
+    }
+    for (let i = 0; i < Math.log(diffStats.deletions); i++) {
+      changeBlocks.push(DeletionBlock)
+    }
+    changeNumber = diffStats.additions + diffStats.deletions
+    changeNumber = changeNumber.toLocaleString()
+  }
   return (
     <div className='github-pr-file' style={style}>
       <span className={`icon ${className}`} />
-      <a href={href} className='link-gray-dark'>{name}</a> {hasComments ? ' 💬' : ''}
+      <a href={href} className='link-gray-dark'>{name}</a>
+      {diffStats &&
+        <span className='changes'>
+          <span className='number'>{changeNumber}</span>
+          {changeBlocks}
+        </span>
+      }
+      {hasComments ? ' 💬' : ''}
     </div>
   )
 }

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -25,6 +25,26 @@ const sorter = (a, b) => {
   }
 }
 
+const parseChangeNumber = (n) => {
+  if (!n.replace) return 0
+  const number = parseInt(n.replace(',', ''), 10)
+  return isNaN(number) ? 0 : number
+}
+
+/**
+ * Get the diff statistics (number of additions and deletions) for a file.
+ */
+const getDiffStatsForDiffElement = (diffElement) => {
+  const diffStatSpan = diffElement.getElementsByClassName('diffstat')[0]
+  const changesTxt = diffStatSpan && diffStatSpan.getAttribute('aria-label')
+  const changes = changesTxt &&
+    changesTxt.match(/([\d,]*) additions? & ([\d,]*) deletions?/)
+  return changes && {
+    additions: parseChangeNumber(changes[1]),
+    deletions: parseChangeNumber(changes[2])
+  }
+}
+
 const hasCommentsForFileIndex = (fileIndex) => {
   const diffTable = document.getElementById(`diff-${fileIndex}`)
   if (!diffTable) {
@@ -103,7 +123,8 @@ export const createFileTree = (filter = EMPTY_FILTER) => {
             href: (index === parts.length - 1) ? href : null,
             hasComments,
             isDeleted,
-            diffElement
+            diffElement,
+            diffStats: getDiffStatsForDiffElement(diffElement)
           }
           location.list.push(node)
         }

--- a/src/js/style.css
+++ b/src/js/style.css
@@ -172,3 +172,24 @@
 .github-pr-file > span {
     margin-right: 4px;
 }
+
+.github-pr-file > span.changes > .number {
+  color: #888888;
+  margin-left: 8px;
+  margin-right: 4px;
+}
+
+.github-pr-file span.addition {
+    background-color: #6cc644;
+}
+
+.github-pr-file span.change-block {
+    display: inline-block;
+    height: 6px;
+    margin-right: 2px;
+    width: 6px;
+}
+
+.github-pr-file span.deletion {
+    background-color: #b22;
+}


### PR DESCRIPTION
Add line change statistics to each file by showing the number of additions and deletions along with a logarithmic amount of blocks showing additions and deletions.

Here's a screenshot of it in action:

<img width="357" alt="Screen Shot 2019-04-04 at 10 04 47 PM" src="https://user-images.githubusercontent.com/3112493/55604686-e3470680-5725-11e9-8e2a-f2d16776ee6c.png">
