### PR TITLE
Add border-color for dark-mode css

### DIFF
--- a/src/js/style.css
+++ b/src/js/style.css
@@ -242,12 +242,8 @@
 
 .__better_github_pr_dark_mode .__better_github_pr {
     border-color: #484848;
-    background-color: #282923;
-    color: #ffffff;
-}
-
-.__better_github_pr_dark_mode .__better_github_pr .link-gray-dark {
-    color: #ffffff !important;
+    background-color: #202020;
+    color: #bebebe;
 }
 
 .__better_github_pr_dark_mode .github-pr-file > span.changes > .number {

--- a/src/js/style.css
+++ b/src/js/style.css
@@ -241,6 +241,7 @@
 /* Dark mode */
 
 .__better_github_pr_dark_mode .__better_github_pr {
+    border-color: #484848;
     background-color: #282923;
     color: #ffffff;
 }


### PR DESCRIPTION
I use a dark theme for GitHub ( https://github.com/StylishThemes/GitHub-Dark-Script/blob/master/README.md ).

The current version of the file viewer has a white background which stands out a bit. This just makes the border darker.

Before:
![Screenshot from 2019-04-16 22-36-56](https://user-images.githubusercontent.com/1225653/56245969-9efa2580-6098-11e9-9ae4-0e9e16e69867.png)

After:
![Screenshot from 2019-04-16 22-38-05](https://user-images.githubusercontent.com/1225653/56245980-a7526080-6098-11e9-87d7-ba3a46d325ec.png)
