### PR TITLE
Remember full screen state

### DIFF
--- a/src/js/components/tree/index.jsx
+++ b/src/js/components/tree/index.jsx
@@ -8,6 +8,7 @@ const MIN_RESIZE_WIDTH = 55
 const MAX_RESIZE_WIDTH = 700
 
 const widthLocalStorageKey = '__better_github_pr_tree_width'
+const fullScreenStorageKey = '__better_github_pr_full_screen'
 
 class Tree extends React.Component {
   constructor (props) {
@@ -28,6 +29,10 @@ class Tree extends React.Component {
     this.reviewContainers = document.querySelectorAll('.enable_better_github_pr #files, .enable_better_github_pr .commit.full-commit.prh-commit')
 
     this.setInitialWidth()
+
+    if (window.localStorage.getItem(fullScreenStorageKey) === 'true') {
+      document.querySelector('body').classList.add('full-width')
+    }
 
     this.state = {
       root: this.props.root,
@@ -128,13 +133,14 @@ class Tree extends React.Component {
   }
 
   onFullWidth () {
-    document.querySelector('body').classList.toggle('full-width')
+    const fullScreenState = document.querySelector('body').classList.toggle('full-width')
+    window.localStorage.setItem(fullScreenStorageKey, fullScreenState)
   }
 
   setInitialWidth () {
-    const savedWitdh = window.localStorage.getItem(widthLocalStorageKey)
-    if (savedWitdh) {
-      this.setWidth(parseInt(savedWitdh, 10))
+    const savedWidth = window.localStorage.getItem(widthLocalStorageKey)
+    if (savedWidth) {
+      this.setWidth(parseInt(savedWidth, 10))
     }
   }
 


### PR DESCRIPTION
I use another plugin for viewing full width GitHub and would be well keen to bin that plugin in favour of this one however the fact the full-screen choice wasn't persistent was a deal breaker :(

Basically stores a boolean flag in localStorage to say if you've full-screened and then applies the class addition if you have.

I don't know if I should be changing the behaviour of the full screen button on the Tree component or if I should have added this kind of github wide flag to the options page... thoughts? Feels like more people would use it if I hooked into the button but not overly passionate either way.

As mentioned: https://github.com/berzniz/github_pr_tree/issues/50