### PR TITLE
Remove sticky header code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Chrome browser extension to show a file tree on GitHub's Pull Request pages.
 - Private repositories support out of the box
 - GitHub Enterprise support
 - Dark mode
-- Other goodies: sticky file headers, resizable tree, expand to full width and more
+- Other goodies: resizable tree, diff stats, expand to full width and more
 
 ![GitHub Pull Request](assets/screenshot.png "GitHub Pull Request")
 

--- a/src/js/style.css
+++ b/src/js/style.css
@@ -117,12 +117,6 @@
     margin-left: 340px;
 }
 
-.enable_better_github_pr #files .file-header {
-    position: sticky;
-    top: 60px;
-    z-index: 1;
-}
-
 .enable_better_github_pr .comment-holder {
     max-width: 708px;
 }


### PR DESCRIPTION
GitHub actually added this feature them selves, with almost the exact same CSS code, yet different enough that the extension code caused a bug (`z-index` mismatch).

This fixes #69