### PR TITLE
Increased the width of files container

### DIFF
--- a/src/js/style.css
+++ b/src/js/style.css
@@ -125,6 +125,10 @@
     transition: width .2s ease;
 }
 
+.enable_better_github_pr .application-main .container-lg {
+    max-width: 1340px;
+}
+
 /* react-treeview */
 
 .tree-view_item {


### PR DESCRIPTION
By adding the sidebar, the width of the actual file has reduced. Because of this many of my team members are feeling it difficult to review PRs as they had to do more horizontal scrolling.

<img width="1680" alt="Screen Shot 2019-10-20 at 5 20 32 PM" src="https://user-images.githubusercontent.com/51014362/67159112-f0dc7a80-f35d-11e9-9883-7c316098ed5c.png">

So, I have increased the width of container by 325px, which the width of the sidebar. This way the files look exactly like before. And the sidebar is also clear.

<img width="1680" alt="Screen Shot 2019-10-20 at 5 19 56 PM" src="https://user-images.githubusercontent.com/51014362/67159113-f76af200-f35d-11e9-9f1c-e0ef3af290e6.png">


Please merge this PR as this is very useful for us.

