### PR TITLE
Add Checkmark Next to Viewed File Name

### DIFF
--- a/src/js/components/file/index.jsx
+++ b/src/js/components/file/index.jsx
@@ -60,6 +60,7 @@ class File extends React.Component {
             <path fillRule='evenodd' d='M14 1H2c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1h2v3.5L7.5 11H14c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zm0 9H7l-2 2v-2H2V2h12v8z' />
           </svg>
         ) : null}
+        { isViewed && <span className='github-pr-file-checkmark'>✅</span> }
       </div>
     )
   }

--- a/src/js/style.css
+++ b/src/js/style.css
@@ -237,6 +237,11 @@
     top: 2px;
 }
 
+.github-pr-file-checkmark {
+  font-size: 10px;
+  padding-left: 5px;
+}
+
 /* Dark mode */
 
 .__better_github_pr_dark_mode .__better_github_pr {


### PR DESCRIPTION
I had a very similar issue to #90 . The bold text does not stand out enough to quickly differentiate  which files I have viewed and which ones I haven't.

Instead of bold I thought it might be better to use a checkmark instead. The checkmark looks just like the checkmark GitHub uses to mark a file as viewed so I thought it was appropriate. However, I am open to suggestions on alternative icons if you don't like the checkmark emoji. 

Here is a screenshot of what it looks like: 
<img width="293" alt="checkmark-example" src="https://user-images.githubusercontent.com/5658781/72398568-5d72d580-3711-11ea-8d85-464277308fae.png">


