### PR TITLE
Fixed firefox support, added popup menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react-treeview": "^0.4.7",
     "source-map-support": "^0.4.15",
     "style-loader": "^0.23.1",
-    "webext-domain-permission-toggle": "^0.1.0",
+    "webext-domain-permission-toggle": "^1.0.0",
+    "webext-dynamic-content-scripts": "6.0.3",
     "webpack": "^4.28.1",
     "webpack-dev-server": "^3.1.14",
     "write-file-webpack-plugin": "^4.5.0"
@@ -48,13 +49,14 @@
     "sanitize-html": "^1.20.0",
     "snazzy": "^7.0.0",
     "standard": "^12.0.1",
-    "webext-dynamic-content-scripts": "^6.0.3",
     "webstore-upload": "^0.0.8"
   },
   "standard": {
     "env": [
       "jest"
     ],
-    "globals": [ "browser" ]
+    "globals": [
+      "browser"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "source-map-support": "^0.4.15",
     "style-loader": "^0.23.1",
     "webext-domain-permission-toggle": "^1.0.0",
-    "webext-dynamic-content-scripts": "6.0.3",
+    "webext-dynamic-content-scripts": "^6.0.3",
     "webpack": "^4.28.1",
     "webpack-dev-server": "^3.1.14",
     "write-file-webpack-plugin": "^4.5.0"

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,4 +1,4 @@
 import 'webext-dynamic-content-scripts'
-import { addContextMenu } from 'webext-domain-permission-toggle'
+import addDomainPermissionToggle from 'webext-domain-permission-toggle'
 
-addContextMenu()
+addDomainPermissionToggle()

--- a/src/js/components/options/index.jsx
+++ b/src/js/components/options/index.jsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { StorageSync } from '../../lib'
 import BodyColor from '../bodyColor'
 
-const url = 'https://chrome.google.com/webstore/detail/github-pull-request-tree/nfhdjopbhlggibjlimhdbogflgmbiahc'
+const chromeStoreUrl = 'https://chrome.google.com/webstore/detail/github-pull-request-tree/nfhdjopbhlggibjlimhdbogflgmbiahc'
+const firefoxStoreUrl = 'https://addons.mozilla.org/en-US/firefox/addon/better-pull-request-for-github/'
 
 class Options extends React.Component {
   constructor (props) {
@@ -20,6 +21,10 @@ class Options extends React.Component {
     this.setState(await StorageSync.get())
   }
 
+  isChrome() {
+    return typeof browser === "undefined"
+  }
+
   render () {
     return (
       <div className='container'>
@@ -27,10 +32,11 @@ class Options extends React.Component {
         <div className='text-center'>
           <h1>Better Pull Request</h1>
           <p>
-            Thanks for using Better Pull Request Chrome Extension! 🎉
+            Thanks for using Better Pull Request {this.isChrome() ? "Chrome" : "Firefox"} Extension! 🎉
           </p>
           <p>
-            If you're enjoying this extension, please <a href={url}>rate it on the Chrome Store</a>.
+            If you're enjoying this extension, please <a href={this.isChrome() ? chromeStoreUrl : firefoxStoreUrl} target="_blank">rate it
+            on the {this.isChrome() ? "Chrome" : "Firefox"} Store</a>.
           </p>
         </div>
         <div>

--- a/src/js/components/tree/index.jsx
+++ b/src/js/components/tree/index.jsx
@@ -127,12 +127,11 @@ class Tree extends React.Component {
   }
 
   onOptions () {
-    const { runtime } = (window.chrome || browser)
-    if (runtime.openOptionsPage) {
-      runtime.openOptionsPage()
-    } else {
-      window.open(runtime.getURL('options.html'))
+    let browserApi = window.chrome
+    if (typeof browser !== "undefined") {
+      browserApi = browser
     }
+    window.open(browserApi.runtime.getURL('options.html'))
   }
 
   onClose () {

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -28,6 +28,9 @@
       "css": []
     }
   ],
+  "browser_action": {
+    "default_popup": "options.html"
+  },
   "options_page": "options.html",
   "web_accessible_resources": ["options.html"],
   "icons": {

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -4,6 +4,7 @@
   "permissions": [
     "contextMenus",
     "storage",
+		"activeTab",
     "*://*.github.com/*"
   ],
   "optional_permissions": [
@@ -13,8 +14,7 @@
   "background": {
     "scripts": [
       "background.js"
-    ],
-    "persistent": false
+    ]
   },
   "content_scripts": [
     {
@@ -28,7 +28,16 @@
       "css": []
     }
   ],
+  "browser_action": {
+    "default_icon": {
+      "16": "16x16.png",
+      "48": "48x48.png",
+      "128": "128x128.png"
+    },
+    "default_popup": "options.html"
+  },
   "options_ui": {
+		"chrome_style": true,
     "page": "options.html"
   },
   "web_accessible_resources": ["options.html"],

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -4,7 +4,7 @@
   "permissions": [
     "contextMenus",
     "storage",
-		"activeTab",
+    "activeTab",
     "*://*.github.com/*"
   ],
   "optional_permissions": [

--- a/src/pages/options.css
+++ b/src/pages/options.css
@@ -4,7 +4,8 @@ body {
 
 .container {
     margin-top: 50px;
-    width: 500px;
+    padding: 0 30px 20px 30px;
+    width: 550px;
 }
 
 .text-center {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8265,12 +8265,14 @@ webext-additional-permissions@^0.1.0:
   dependencies:
     "@types/chrome" "0.0.86"
 
-webext-domain-permission-toggle@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/webext-domain-permission-toggle/-/webext-domain-permission-toggle-0.1.0.tgz#82c0f611a075958e5b879fd77f69908236615607"
-  integrity sha512-zPwVKYa5EiH0htXedmoAWUaMqU7pOr+4dlzFyGVM64Q0jLVo3V8AVcYOVDKtY+c9qOkhtoSUCGcXCnbs5u8eNg==
+webext-domain-permission-toggle@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/webext-domain-permission-toggle/-/webext-domain-permission-toggle-1.0.0.tgz#6f9a6d3234ffe596921d1be5ae8823ef5b02ebd2"
+  integrity sha512-K6RAOYtVCMAmqjQPopMbGOIoxpFU05ERGgaLkUNvFCdpPsXLB5y4m1+Cq1dezyfx6FU0lLEqxoL/5/49+EY5zA==
+  dependencies:
+    webext-additional-permissions "^0.1.0"
 
-webext-dynamic-content-scripts@^6.0.3:
+webext-dynamic-content-scripts@6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-6.0.3.tgz#729a5cf4408dca589af889cb403943ab414c2ecd"
   integrity sha512-MIH4UOnkUl4hapl83uMQT5t2bbYXTPO/mxhFFBcesm2mGvnG3OrNKNiaPRFL6AdcPvqDVae8UcWcWHSflptLTQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8272,7 +8272,7 @@ webext-domain-permission-toggle@^1.0.0:
   dependencies:
     webext-additional-permissions "^0.1.0"
 
-webext-dynamic-content-scripts@6.0.3:
+webext-dynamic-content-scripts@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-6.0.3.tgz#729a5cf4408dca589af889cb403943ab414c2ecd"
   integrity sha512-MIH4UOnkUl4hapl83uMQT5t2bbYXTPO/mxhFFBcesm2mGvnG3OrNKNiaPRFL6AdcPvqDVae8UcWcWHSflptLTQ==


### PR DESCRIPTION
## In this PR
- Fixed #93.
- Added popup menu to the extension icon, added padding to the popup
- Fixed opening extension options in firefox from the PR tree
- Added Firefox store link when in Firefox


## Screenshots

### Firefox left-click popup
![firefox_popup](https://user-images.githubusercontent.com/28873048/78274491-9b151c80-7510-11ea-8690-a6d06defdbae.png)

### Firefox right-click menu
![firefox_rightclick](https://user-images.githubusercontent.com/28873048/78274533-a9fbcf00-7510-11ea-96c3-6fbef428bb68.png)

### Firefox extension settings
![firefox_options](https://user-images.githubusercontent.com/28873048/78274562-b5e79100-7510-11ea-8365-3239dcedf650.png)

### Firefox options from PR tree
![firefox-options-from-page](https://user-images.githubusercontent.com/28873048/78274939-38705080-7511-11ea-9d58-ac30bc564ecf.gif)

### Chrome left-click popup
![chrome_popup](https://user-images.githubusercontent.com/28873048/78275061-69e91c00-7511-11ea-9756-866e272735f1.png)
