### PR TITLE
Added popup options to chrome

### DIFF
--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -28,6 +28,14 @@
       "css": []
     }
   ],
+  "browser_action": {
+    "default_icon": {
+      "16": "16x16.png",
+      "48": "48x48.png",
+      "128": "128x128.png"
+    },
+    "default_popup": "options.html"
+  },
   "options_page": "options.html",
   "web_accessible_resources": ["options.html"],
   "icons": {


### PR DESCRIPTION
Moved the discussion about chrome popup here.

> @berzniz I took a look on the options popup on Chrome, and it worked like charm to me. I could modify the settings and the were applied after a tab refresh. My chrome version was `81.0.4044.92 (64 bit)` and I built and loaded the extension in dev mode.

_Originally posted in https://github.com/berzniz/github_pr_tree/pull/103#issuecomment-612959729_