### PR TITLE
fix: fileId when CODEOWNERS exists

### DIFF
--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -110,7 +110,7 @@ export const folderConcat = (node) => {
 }
 
 export const createFileTree = (filter = EMPTY_FILTER) => {
-  const fileInfo = [...document.querySelectorAll('.file-info > a')]
+  const fileInfo = [...document.querySelectorAll('.file-info > a.link-gray-dark')]
   const files = fileInfo.map(({ title, href }) => {
     title = getCurrentFileLocation(title)
     return { title, href, parts: title.split('/') }


### PR DESCRIPTION
fix #110 

Screenshot

<img width="1411" alt="Screen Shot 2020-05-01 at 08 48 06" src="https://user-images.githubusercontent.com/4651658/80774959-83b96580-8b88-11ea-81cc-906ebbac7eec.png">


@berzniz  please help to review & test. working fine on my Chrome Mac 🙏 