### PR TITLE
Add toggle comments button

### DIFF
--- a/src/js/components/actions/index.jsx
+++ b/src/js/components/actions/index.jsx
@@ -1,8 +1,16 @@
 import React from 'react'
 
-const Actions = ({ filter, filterFiles, onFullWidth, onOptions, onClose }) => (
+const Actions = ({ filter, filterFiles, onFullWidth, onOptions, onClose, onToggleComments }) => (
   <div className='actions'>
     <input type='text' value={filter} className='actions-filter' placeholder='Type to filter files' onChange={filterFiles} />
+
+    <div className='actions-small-button'>
+      <button onClick={onToggleComments} className='full-width-button' title='Toggle comments'>
+        <svg className='octicon' xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'>
+          <path fillRule='evenodd' d='M14 1H2c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1h2v3.5L7.5 11H14c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zm0 9H7l-2 2v-2H2V2h12v8z' />
+        </svg>
+      </button>
+    </div>
 
     <div className='actions-small-button'>
       <button onClick={onFullWidth} className='full-width-button' title='Toggle maximum width of github content'>

--- a/src/js/components/tree/index.jsx
+++ b/src/js/components/tree/index.jsx
@@ -10,6 +10,7 @@ const MAX_RESIZE_WIDTH = 700
 const widthLocalStorageKey = '__better_github_pr_tree_width'
 const fullScreenStorageKey = '__better_github_pr_full_screen'
 
+const appendIconClassName = '__toggle_comments_append'
 class Tree extends React.Component {
   constructor (props) {
     super(props)
@@ -22,6 +23,7 @@ class Tree extends React.Component {
     this.onFullWidth = this.onFullWidth.bind(this)
     this.filterFiles = this.filterFiles.bind(this)
     this.onClick = this.onClick.bind(this)
+    this.onToggleComments = this.onToggleComments.bind(this)
 
     this.isResizing = false
     this.resizeDelta = 0
@@ -137,6 +139,30 @@ class Tree extends React.Component {
     this.setWidth(0, false)
   }
 
+  onToggleComments () {
+    document.querySelectorAll('.js-toggle-file-notes').forEach((el) => {
+      el.click()
+    })
+
+    document.querySelectorAll('.js-diff-progressive-container .inline-comments').forEach((el) => {
+      // last TD in previouse line
+      const td = el.previousElementSibling.lastElementChild
+      const lastEl = td.lastElementChild
+      if (lastEl.classList.contains(appendIconClassName)) {
+        // already appended, remove
+        lastEl.remove()
+      } else {
+        const span = document.createElement('span')
+        span.className = appendIconClassName
+        const svg = '<svg className="octicon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">' +
+          '<path fillRule="evenodd" fill="red" d="M14 1H2c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1h2v3.5L7.5 11H14c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zm0 9H7l-2" />' +
+          '</svg>'
+        span.innerHTML = svg
+        td.append(span)
+      }
+    })
+  }
+
   onFullWidth () {
     const fullScreenState = document.querySelector('body').classList.toggle('full-width')
     window.localStorage.setItem(fullScreenStorageKey, fullScreenState)
@@ -189,6 +215,7 @@ class Tree extends React.Component {
           onFullWidth={this.onFullWidth}
           onOptions={this.onOptions}
           onClose={this.onClose}
+          onToggleComments={this.onToggleComments}
         />
         <div className='file-container'>
           <div>

--- a/src/js/style.css
+++ b/src/js/style.css
@@ -283,3 +283,8 @@
     background: #e4af3c;
     color: #333333;
 }
+.__toggle_comments_append {
+    left: 1px;
+    position: relative;
+    top: -5px;
+}


### PR DESCRIPTION
Related issue https://github.com/berzniz/github_pr_tree/issues/114

Add a button that can toggle all comments show/hide.

![image](https://user-images.githubusercontent.com/58177/81034895-41b35b00-8ecb-11ea-8a85-54ecae49ac1f.png)

After hide comments, here will append an icon to notify user.

![image](https://user-images.githubusercontent.com/58177/81034998-a373c500-8ecb-11ea-826b-ba49252da74b.png)

I think it's enough for my daily use, but there are still some improvements could be done:
1. Add click event to the appended icon, so that user can show/hide the comment through click.
2. The click event should connected with the click event from the original `show comments` menu.