### PR TITLE
fix: style issue in github enterprise

### DIFF
--- a/src/js/style.css
+++ b/src/js/style.css
@@ -5,6 +5,7 @@
 
 .__better_github_pr {
     display: none;
+    top: 0;
 
     /* Fallbacks - We will try to use github's colors first */
     --bgpr-background: #fff;


### PR DESCRIPTION
Though this is not an issue in github itself, I do see it in github enterprise edition. And, it's very annoying. See the attached picture.

![image](https://user-images.githubusercontent.com/1917351/121778860-80860b00-cbcb-11eb-86b8-dc254fe3b6c2.png)
