### PR TITLE
Adjust usage of Github color vars

### DIFF
--- a/src/js/style.css
+++ b/src/js/style.css
@@ -115,9 +115,9 @@
     padding: 5px 10px;
     border-radius: 4px;
     outline: none;
-    background: var(--color-auto-gray-2, var(--bgpr-filter-background));
+    background: var(--color-bg-secondary, var(--bgpr-filter-background));
     color: var(--color-diff-blob-hunk-text, var(--bgpr-filter-color));
-    border: 1px solid var(--color-auto-gray-2, var(--bgpr-filter-border));
+    border: 1px solid var(--color-input-border, var(--bgpr-filter-border));
     transition: border .2s;
 }
 .__better_github_pr .actions-filter::placeholder {
@@ -182,7 +182,7 @@
 }
 
 .tree-view_item:hover {
-    background-color: var(--color-auto-gray-2, var(--bgpr-item-hover-background));
+    background-color: var(--color-bg-info, var(--bgpr-item-hover-background));
 }
 
 .tree-view_arrow {
@@ -238,7 +238,7 @@
 }
 
 .github-pr-file.github-pr-file-highlight {
-    background: var(--color-auto-gray-2, var(--bgpr-file-highlight-background));
+    background: var(--color-bg-info, var(--bgpr-file-highlight-background));
 }
 
 .github-pr-file.github-pr-file-deleted {


### PR DESCRIPTION
Github is seemingly removing the various grayscale variables, in favor of more specific ones. Fixes #163

Demo with current GitHub version:

![image](https://user-images.githubusercontent.com/6775216/130837973-37f14602-94a4-438b-a255-0abe20273696.png)

Demo with Dark Contrast feature enabled:

![image](https://user-images.githubusercontent.com/6775216/130838114-114819db-e63d-40e1-bc9c-457a81d75be4.png)

Dark mode:

![image](https://user-images.githubusercontent.com/6775216/130838302-2ee5d232-2652-4153-8b8d-15805f70b51a.png)
