### PR TITLE
Define webpack `publicPath`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,9 @@ const copyWebpackPlugins = [
   { from: './src/pages/options.css' }
 ]
 
+// Try the environment variable, otherwise use root
+const ASSET_PATH = process.env.ASSET_PATH || '/'
+
 module.exports = {
   mode: NODE_ENV,
   entry: {
@@ -19,6 +22,7 @@ module.exports = {
   },
   output: {
     path: path.join(__dirname, 'build', TARGET, NODE_ENV),
+    publicPath: ASSET_PATH,
     filename: '[name].js'
   },
   module: {


### PR DESCRIPTION
This commit fixes the webpack error "Automatic publicPath is not supported in this browser", which I catch in browser Vivaldi 3.6.2165.3 for Ubuntu 64bit (based on Chromium), and which breaks the extension in this browser (although it worked well at least before September 2021).

The solution is copied from the documentation: https://webpack.js.org/guides/public-path/
I have also tried option `publicPath: 'auto'` from the documentation, but it did not work (the extension was broken, like before)