### PR TITLE
Filter diff files as well as tree view

### DIFF
--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -128,13 +128,18 @@ export const createFileTree = (filter = EMPTY_FILTER) => {
 
   files.forEach(({ parts, href }) => {
     let location = tree
+
+    const hrefSplit = href.split('#')
+    const fileId = hrefSplit[hrefSplit.length - 1]
+    const diffElement = getDiffElement(fileId)
+
     if (filterItem(parts[parts.length - 1], filter)) {
+      if (diffElement) {
+        diffElement.style.display = ''
+      }
       parts.forEach((part, index) => {
         let node = location.list.find(node => node.nodeLabel === part)
         if (!node) {
-          const hrefSplit = href.split('#')
-          const fileId = hrefSplit[hrefSplit.length - 1]
-          const diffElement = getDiffElement(fileId)
           if (diffElement) {
             const hasComments = (countCommentsForFileId(fileId) > 0)
             const isDeleted = isDeletedForFileId(fileId)
@@ -154,6 +159,8 @@ export const createFileTree = (filter = EMPTY_FILTER) => {
         location.list = location.list.sort(sorter)
         location = node
       })
+    } else if (diffElement) {
+      diffElement.style.display = 'none'
     }
   })
   return {


### PR DESCRIPTION
This is quite simplistic and just uses `style='none'`, happy to use a CSS class instead. It does mean that it would remove any other content that existed in `style`, but as it stands the element doesn't have any styles applied to it. Some of the nested divs do use `style` - e.g. the header of the diff file uses `style="top: 60px !important; position: sticky;"`

I was thinking with CSS classes they may be more likely to be overridden by Github code causing the diffs to reappear.