### PR TITLE
Viewed item background highlighting

### DIFF
--- a/src/js/components/file/index.jsx
+++ b/src/js/components/file/index.jsx
@@ -49,10 +49,12 @@ class File extends React.Component {
 
     const index = filter ? (name.toLowerCase() || '').indexOf(filter.toLowerCase()) : -1
     const highlightedName = (index === -1) ? name : this.getHighlight({ name, filter, index })
+    
+    const backgroundHighlightColor = '#E6FFED'
 
     return (
-      <div className={topClassName}>
-        <span className={`icon ${className}`} />
+      <div className={topClassName} style={isViewed && options.viewedFileBackground ? {backgroundColor: backgroundHighlightColor} : null }>
+        <span className={`icon ${className}`}/>
         <a href={href} className='link-gray-dark'>{highlightedName}</a>
         {options.diffStats && diffStats && <DiffStats diffStats={diffStats} />}
         {hasComments

--- a/src/js/components/options/index.jsx
+++ b/src/js/components/options/index.jsx
@@ -47,6 +47,15 @@ class Options extends React.Component {
             />
             <span className='label-body'>Show <strong>Diff Stats</strong> next to files</span>
           </label>
+          <label className='label-enabledd'>
+            <input
+              id='viewedFileBackground'
+              type='checkbox'
+              checked={Boolean(this.state.viewedFileBackground)}
+              onChange={this.handleOptions}
+            />
+            <span className='label-body'><strong>Highlight Background</strong> of files marked viewed</span>
+          </label>
         </div>
       </div>
     )

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -204,8 +204,10 @@ export const StorageSync = {
   save () {
     return new Promise(resolve => {
       const diffStats = document.getElementById('diffStats').checked
+      const viewedFileBackground = document.getElementById('viewedFileBackground').checked
       const options = {
-        diffStats
+        diffStats,
+        viewedFileBackground
       }
 
       if (window.chrome) {
@@ -218,7 +220,8 @@ export const StorageSync = {
   get () {
     return new Promise(resolve => {
       const defaults = {
-        diffStats: false
+        diffStats: false,
+        viewedFileBackground: false
       }
       if (window.chrome) {
         window.chrome.storage.sync.get(defaults, resolve)


### PR DESCRIPTION

<h2> Summary </h2>

Adds a new option to the options page to allow for toggling background highlighting of already viewed files. This allows for additional information at a glance when combined with the checkmark. 

The color was selected to be the same as the github additional line added color. 


<h2> Change Preivew: </h2>

![image](https://user-images.githubusercontent.com/8051409/135355634-da2d5b92-bc91-4bf2-97b2-58172ad23ae6.png)


<h2> Options page addition:</h2>

![image](https://user-images.githubusercontent.com/8051409/135355657-3cfa1965-efdd-4575-b271-51299184089c.png)
