### PR TITLE
Use Github's sort order

### DIFF
--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -13,18 +13,6 @@ export const createRootElement = () => {
   return element
 }
 
-const sorter = (a, b) => {
-  const isFileA = Boolean(a.href)
-  const isFileB = Boolean(b.href)
-  if (isFileA === isFileB) {
-    return (b.nodeLabel > a.nodeLabel) ? -1 : ((a.nodeLabel > b.nodeLabel) ? 1 : 0)
-  } else if (isFileA && !isFileB) {
-    return 1
-  } else {
-    return -1
-  }
-}
-
 const parseChangeNumber = (n) => {
   if (!n.replace) return 0
   const number = parseInt(n.replace(',', ''), 10)
@@ -115,9 +103,9 @@ export const folderConcat = (node) => {
 
 export const createFileTree = (filter = EMPTY_FILTER) => {
   const fileInfo = [...document.querySelectorAll('.file-info > a')]
-  const files = fileInfo.map(({ title, href }) => {
+  const files = fileInfo.map(({ title, href }, idx) => {
     title = getCurrentFileLocation(title)
-    return { title, href, parts: title.split('/') }
+    return { title, href, parts: title.split('/'), idx }
   })
   const count = fileInfo.filter(({ href }) => href && href.includes('#diff')).length
   const tree = {
@@ -126,7 +114,7 @@ export const createFileTree = (filter = EMPTY_FILTER) => {
     diffElements: []
   }
 
-  files.forEach(({ parts, href }) => {
+  files.forEach(({ parts, href, idx }) => {
     let location = tree
     if (filterItem(parts[parts.length - 1], filter)) {
       parts.forEach((part, index) => {
@@ -140,6 +128,7 @@ export const createFileTree = (filter = EMPTY_FILTER) => {
             const isDeleted = isDeletedForFileId(fileId)
             tree.diffElements.push(diffElement)
             node = {
+              idx,
               nodeLabel: part,
               list: [],
               href: (index === parts.length - 1) ? href : null,
@@ -151,7 +140,7 @@ export const createFileTree = (filter = EMPTY_FILTER) => {
             location.list.push(node)
           }
         }
-        location.list = location.list.sort(sorter)
+        location.list = location.list.sort((a, b) => a.idx - b.idx)
         location = node
       })
     }


### PR DESCRIPTION
The existing sorting method uses a couple of heuristics to sort -
however, there are cases where the resulting sorting does not match
the order in which Github displays the files.

As a result, scrolling down the list can cause the selected file in the
tree to jump around rather than going down one-by-one.

This commit removes most of the sorting logic and instead uses the index
of the name of the file on the page, guaranteeing the tree matches
Github even if they change their ordering logic.

Fixes #187