### PR TITLE
feat: add support for GH custom domains

### DIFF
--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -4,7 +4,7 @@
   "permissions": [
     "contextMenus",
     "storage",
-    "*://*.github.com/*"
+    "*://*.github.*"
   ],
   "optional_permissions": [
     "http://*/*",
@@ -19,7 +19,7 @@
   "content_scripts": [
     {
       "matches": [
-        "*://*.github.com/*"
+        "*://*.github.*"
       ],
       "run_at": "document_idle",
       "js": [

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -5,7 +5,7 @@
     "contextMenus",
     "storage",
     "activeTab",
-    "*://*.github.com/*"
+    "*://*.github.*"
   ],
   "optional_permissions": [
     "http://*/*",
@@ -19,7 +19,7 @@
   "content_scripts": [
     {
       "matches": [
-        "*://*.github.com/*"
+        "*://*.github.*"
       ],
       "run_at": "document_idle",
       "js": [


### PR DESCRIPTION
Added the support for any custom domain of GitHub.
The target is that the enterprise users can also use the extension.