### PR TITLE
Fix for changed HTML structure

### DIFF
--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -114,7 +114,7 @@ export const folderConcat = (node) => {
 }
 
 export const createFileTree = (filter = EMPTY_FILTER) => {
-  const fileInfo = [...document.querySelectorAll('.file-info > a')]
+  const fileInfo = [...document.querySelectorAll('.file-info a')]
   const files = fileInfo.map(({ title, href }) => {
     title = getCurrentFileLocation(title)
     return { title, href, parts: title.split('/') }


### PR DESCRIPTION
Fix #206 

Seems like GitHub recently added a `.Truncate` wrapper element. (Isn't there in test file https://github.com/berzniz/github_pr_tree/blob/master/src/js/__tests__/fixtures/pr_with_comment.html#L924-L945)

![Screenshot 2022-04-05 at 09 27 43](https://user-images.githubusercontent.com/38662306/161701787-fcf7d4d5-449f-474c-b55a-ce80c5a78082.png)
