### PR TITLE
(fix): Reduce margins on file container for large screens

### DIFF
--- a/src/js/style.css
+++ b/src/js/style.css
@@ -169,6 +169,14 @@
     margin-left: 340px;
 }
 
+@media (min-width: 1012px) {
+    .enable_better_github_pr #files,
+    .enable_better_github_pr .commit.full-commit.prh-commit {
+        margin-left: 30px;
+    }
+}
+
+
 .enable_better_github_pr .comment-holder {
     max-width: 708px;
 }


### PR DESCRIPTION
Remove extra margin on screens that are larger than `1012px`. It was creating a large whitespace. 
**Before:**
<img width="1158" alt="Screen Shot 2022-08-31 at 10 54 11 AM" src="https://user-images.githubusercontent.com/4571750/187746819-f6a6c765-00f8-4794-b262-7be6f209601c.png">

**After:**
<img width="1164" alt="Screen Shot 2022-08-31 at 10 54 54 AM" src="https://user-images.githubusercontent.com/4571750/187746828-8f372a51-faa7-4129-ad7b-a944752e97a2.png">
